### PR TITLE
chore: mark project as Production/Stable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [{ name = "Wataru" }]
 requires-python = ">=3.9"
 keywords = ["fastapi", "cli", "testing", "http-client", "testclient", "api-testing"]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python",


### PR DESCRIPTION
## Summary
- Update PyPI Trove classifier from Alpha to Production/Stable.

Closes #11.

## Test plan
- [x] `pytest`
- [x] `python -m build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Marks the package as production-ready.
> 
> - Updates the PyPI Trove classifier in `pyproject.toml` from `Development Status :: 3 - Alpha` to `Development Status :: 5 - Production/Stable`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9c38ebb2dbc13bfd80f5314debaf0c80361f605. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->