### PR TITLE
Docs: OpenSpec change for streaming response support

### DIFF
--- a/openspec/changes/add-streaming-response-support/proposal.md
+++ b/openspec/changes/add-streaming-response-support/proposal.md
@@ -1,0 +1,14 @@
+# Change: Add StreamingResponse support to `fapi-cli request`
+
+## Why
+FastAPI の `StreamingResponse` を返すエンドポイントに対して、現状の `fapi-cli request` はレスポンス全体を読み切ってから出力するため、ストリーミング用途（大容量ダウンロード、逐次出力など）で実用的ではない。
+
+## What Changes
+- `fapi-cli request` に `--stream` オプションを追加し、レスポンスボディを **バッファせず** 受信した順に標準出力へ書き出す。
+- `--stream` 指定時は、通常モードの JSON 出力（`status_code` / `body` / 任意で `headers`）を行わない（**出力形式が異なる**）。
+- `--stream` と `--include-headers` の同時指定はエラーにする（出力形式の衝突を避けるため）。
+
+## Impact
+- Affected specs: `openspec/specs/cli-tool/spec.md`
+- Affected code: `src/fapi_cli/cli.py`, `tests/test_request_command.py`, `README.md`, `README.ja.md`, `AGENTS.md`
+

--- a/openspec/changes/add-streaming-response-support/specs/cli-tool/spec.md
+++ b/openspec/changes/add-streaming-response-support/specs/cli-tool/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+### Requirement: Streaming Response Support
+The CLI tool SHALL support streaming response bodies when the user specifies the `--stream` option, without buffering the entire response in memory.
+
+#### Scenario: Stream plain text response
+- **WHEN** user executes `fapi-cli request app.py -P /stream --stream`
+- **THEN** the tool writes the response body bytes to stdout as they are received, preserving chunk order
+
+#### Scenario: Stream binary response
+- **WHEN** user executes `fapi-cli request app.py -P /download --stream > out.bin`
+- **THEN** the tool writes the response body bytes to stdout without attempting to decode as text or JSON
+
+#### Scenario: Invalid combination with headers output
+- **WHEN** user executes `fapi-cli request app.py -P /stream --stream --include-headers`
+- **THEN** the tool outputs a clear error message indicating the options cannot be used together and exits with code 1
+
+## MODIFIED Requirements
+### Requirement: Response Output Format
+The CLI tool SHALL output responses in a structured JSON format to stdout, except when streaming mode is enabled.
+
+#### Scenario: Successful response output (default mode)
+- **WHEN** a request succeeds with status 200 and `--stream` is not specified
+- **THEN** the tool outputs JSON containing at least `status_code` and `body` fields
+
+#### Scenario: Error response output (default mode)
+- **WHEN** a request fails with status 404 or 500 and `--stream` is not specified
+- **THEN** the tool outputs JSON containing `status_code` and `body` fields with error details
+
+#### Scenario: Response headers output (optional, default mode)
+- **WHEN** user specifies `--include-headers` flag and `--stream` is not specified
+- **THEN** the tool includes response headers in the output JSON
+
+#### Scenario: Streaming response output (stream mode)
+- **WHEN** user specifies `--stream`
+- **THEN** the tool writes response body bytes to stdout as they are received and does not emit the structured JSON response wrapper
+

--- a/openspec/changes/add-streaming-response-support/tasks.md
+++ b/openspec/changes/add-streaming-response-support/tasks.md
@@ -1,0 +1,10 @@
+## 1. Implementation
+- [ ] 1.1 Add `--stream` option to `fapi-cli request` (CLI surface)
+- [ ] 1.2 Enforce `--stream` incompatibility with `--include-headers` (clear error + exit code 1)
+- [ ] 1.3 Implement streaming execution path using `httpx.AsyncClient.stream(...)`
+- [ ] 1.4 Add tests for `StreamingResponse` (text stream at minimum)
+- [ ] 1.5 Update docs: `README.md`, `README.ja.md`, and root `AGENTS.md`
+
+## 2. Validation
+- [ ] 2.1 Run `openspec validate add-streaming-response-support --strict` and fix findings
+


### PR DESCRIPTION
## Summary
- Add OpenSpec change proposal/tasks/spec delta for Issue #12 (StreamingResponse support).
- Define `--stream` behavior and incompatibility with `--include-headers`.

## Test plan
- [x] `openspec validate add-streaming-response-support --strict`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds OpenSpec change set defining streaming support for `fapi-cli request` and a task checklist for implementation.
> 
> - **ADDED**: `--stream` option requirement to write response bytes to stdout as received (no buffering), covering text and binary
> - **MODIFIED**: default response output remains structured JSON; in stream mode the JSON wrapper is not emitted
> - **Validation/Errors**: `--stream` cannot be combined with `--include-headers`; must error with exit code 1
> - **Tasks**: implement streaming via `httpx.AsyncClient.stream(...)`, add tests, and update docs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9db9234f201d56cc07e362fac7b09f369eb8a8d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->